### PR TITLE
Convert .check() into an EventEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation
 
 * [imageWrite](#module_imageWrite)
   * [.write(device, stream)](#module_imageWrite.write) ⇒ <code>EventEmitter</code>
-  * [.check(device, stream)](#module_imageWrite.check) ⇒ <code>Promise</code>
+  * [.check(device, stream)](#module_imageWrite.check) ⇒ <code>EventEmitter</code>
 
 <a name="module_imageWrite.write"></a>
 ### imageWrite.write(device, stream) ⇒ <code>EventEmitter</code>
@@ -85,7 +85,7 @@ emitter.on 'done', ->
 	console.log('Finished writing to device')
 ```
 <a name="module_imageWrite.check"></a>
-### imageWrite.check(device, stream) ⇒ <code>Promise</code>
+### imageWrite.check(device, stream) ⇒ <code>EventEmitter</code>
 This function can be used after `write()` to ensure
 the image was successfully written to the device.
 
@@ -97,10 +97,15 @@ to create another readable stream from the image since
 the one used previously has all its data consumed already,
 so it will emit no `data` event, leading to false results.
 
+The returned EventEmitter instance emits the following events:
+
+- `error`: An error event.
+- `done`: An event emitted with a boolean value determining the result of the check.
+
 **Kind**: static method of <code>[imageWrite](#module_imageWrite)</code>  
 **Summary**: Write a readable stream to a device  
+**Returns**: <code>EventEmitter</code> - - emitter  
 **Access:** public  
-**Fulfil**: <code>Boolean</code> - whether the write was successful  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -112,7 +117,12 @@ so it will emit no `data` event, leading to false results.
 myStream = fs.createReadStream('my/image')
 myStream.length = fs.statSync('my/image').size
 
-imageWrite.check('/dev/disk2', myStream).then (success) ->
+checker = imageWrite.check('/dev/disk2', myStream)
+
+checker.on 'error', (error) ->
+	console.error(error)
+
+checker.on 'done', (success) ->
 	if success
 		console.log('The write was successful')
 ```

--- a/build/write.js
+++ b/build/write.js
@@ -140,23 +140,33 @@ exports.write = function(device, stream) {
  * the one used previously has all its data consumed already,
  * so it will emit no `data` event, leading to false results.
  *
+ * The returned EventEmitter instance emits the following events:
+ *
+ * - `error`: An error event.
+ * - `done`: An event emitted with a boolean value determining the result of the check.
+ *
  * @param {String} device - device
  * @param {ReadStream} stream - image readable stream
- *
- * @fulfil {Boolean} - whether the write was successful
- * @returns {Promise}
+ * @returns {EventEmitter} - emitter
  *
  * @example
  * myStream = fs.createReadStream('my/image')
  * myStream.length = fs.statSync('my/image').size
  *
- * imageWrite.check('/dev/disk2', myStream).then (success) ->
+ * checker = imageWrite.check('/dev/disk2', myStream)
+ *
+ * checker.on 'error', (error) ->
+ * 	console.error(error)
+ *
+ * checker.on 'done', (success) ->
  * 	if success
  * 		console.log('The write was successful')
  */
 
 exports.check = function(device, stream) {
-  return Promise["try"](function() {
+  var emitter;
+  emitter = new EventEmitter();
+  Promise["try"](function() {
     if (stream.length == null) {
       throw new Error('Stream size missing');
     }
@@ -170,6 +180,9 @@ exports.check = function(device, stream) {
       })
     });
   }).then(function(checksums) {
-    return checksums.stream === checksums.device;
+    return emitter.emit('done', checksums.stream === checksums.device);
+  })["catch"](function(error) {
+    return emitter.emit('error', error);
   });
+  return emitter;
 };


### PR DESCRIPTION
This change will make it easier to emit a progress state to the client
later on.