### PR TITLE
Make write check work in OS X and Windows

### DIFF
--- a/example.js
+++ b/example.js
@@ -13,28 +13,18 @@ function onError(error) {
 	process.exit(1);
 }
 
-function getImageStream() {
-	stream = fs.createReadStream(image);
-	stream.length = fs.statSync(image).size;
-	return stream;
-}
+stream = fs.createReadStream(image);
+stream.length = fs.statSync(image).size;
 
-imageWrite.write(drive, getImageStream())
+imageWrite.write(drive, stream, { check: true })
 	.on('error', onError)
 	.on('progress', function(state) {
-		console.log('Writing', state);
+		console.log(state);
 	})
-	.on('done', function() {
-		imageWrite.check(drive, getImageStream())
-			.on('error', onError)
-			.on('progress', function(state) {
-				console.log('Checking', state);
-			})
-			.on('done', function(success) {
-				if (success) {
-					console.log('Check passed');
-				} else {
-					console.error('Check failed');
-				}
-			});
+	.on('done', function(success) {
+		if (success) {
+			console.log('Check passed');
+		} else {
+			console.error('Check failed');
+		}
 	});

--- a/lib/write.coffee
+++ b/lib/write.coffee
@@ -24,9 +24,12 @@ _ = require('lodash')
 Promise = require('bluebird')
 progressStream = require('progress-stream')
 StreamChunker = require('stream-chunker')
+denymount = Promise.promisify(require('denymount'))
 utils = require('./utils')
 win32 = require('./win32')
 checksum = require('./checksum')
+
+CHUNK_SIZE = 65536 * 16 # 64K * 16 = 1024K = 1M
 
 ###*
 # @summary Write a readable stream to a device
@@ -35,13 +38,15 @@ checksum = require('./checksum')
 #
 # @description
 #
-# **NOTICE:** You might need to run this function as sudo/administrator to avoid permission issues.
+# **NOTICE:** You might need to run this function as sudo/administrator to
+# avoid permission issues.
 #
 # The returned EventEmitter instance emits the following events:
 #
 # - `progress`: A progress event that passes a state object of the form:
 #
 #		{
+#			type: 'write' // possible values: 'write', 'check'.
 #			percentage: 9.05,
 #			transferred: 949624,
 #			length: 10485760,
@@ -53,19 +58,27 @@ checksum = require('./checksum')
 #		}
 #
 # - `error`: An error event.
-# - `done`: An event emitted when the readable stream was written completely.
+# - `done`: An event emitted with a boolean success value.
 #
-# If you're passing a readable stream from a custom location, you can configure the length by adding a `.length` number property to the stream.
+# If you're passing a readable stream from a custom location, you should
+# configure the length by adding a `.length` number property to the stream.
+#
+# Enabling the `check` option is useful to ensure the image was
+# successfully written to the device. This is checked by calculating and
+# comparing checksums from both the original image and the data written
+# to the device.
 #
 # @param {String} device - device
 # @param {ReadStream} stream - readable stream
+# @param {Object} [options={}] - options
+# @param {Boolean} [options.check=false] - enable write check
 # @returns {EventEmitter} emitter
 #
 # @example
 # myStream = fs.createReadStream('my/image')
 # myStream.length = fs.statSync('my/image').size
 #
-# emitter = imageWrite.write('/dev/disk2', myStream)
+# emitter = imageWrite.write('/dev/disk2', myStream, check: true)
 #
 # emitter.on 'progress', (state) ->
 # 	console.log(state)
@@ -73,10 +86,13 @@ checksum = require('./checksum')
 # emitter.on 'error', (error) ->
 # 	console.error(error)
 #
-# emitter.on 'done', ->
-# 	console.log('Finished writing to device')
+# emitter.on 'done', (success) ->
+# 	if success
+# 		console.log('Success!')
+# 	else
+# 		console.log('Failed!')
 ###
-exports.write = (device, stream) ->
+exports.write = (device, stream, options = {}) ->
 	emitter = new EventEmitter()
 
 	if not stream.length?
@@ -89,20 +105,44 @@ exports.write = (device, stream) ->
 		time: 500
 
 	progress.on 'progress', (state) ->
+		state.type = 'write'
 		emitter.emit('progress', state)
 
-	chunkSize = 65536 * 16 # 64K * 16 = 1024K = 1M
-
 	utils.eraseMBR(device).then(win32.prepare).then ->
-		Promise.fromNode (callback) ->
-			stream
-				.pipe(progress)
-				.pipe(StreamChunker(chunkSize, flush: true))
-				.pipe(fs.createWriteStream(device, flags: 'rs+'))
-				.on('close', callback)
-				.on('error', callback)
-	.then(win32.prepare).then ->
-		emitter.emit('done')
+		Promise.props
+			checksum: checksum.calculate(stream, bytes: stream.length)
+			write: new Promise (resolve, reject) ->
+				stream
+					.pipe(progress)
+					.pipe(StreamChunker(CHUNK_SIZE, flush: true))
+					.pipe(fs.createWriteStream(device, flags: 'rs+'))
+					.on('close', resolve)
+					.on('error', reject)
+	.get('checksum')
+	.then (imageChecksum) ->
+		if not options.check
+			return win32.prepare().then ->
+				emitter.emit('done', true)
+
+		# Prevent disks from auto-mounting, since some OSes, like
+		# Windows and OS X, "touch" files in FAT partitions,
+		# causing our checksum comparison to fail.
+		return denymount device, (callback) ->
+
+			# Only calculate the checksum from the bytes that correspond
+			# to the original image size and not the whole drive since
+			# the drive might contain empty space that changes the
+			# resulting checksum.
+			# See https://help.ubuntu.com/community/HowToMD5SUM#Check_the_CD
+			return checksum.calculate fs.createReadStream(device),
+				bytes: stream.length
+				progress: (state) ->
+					state.type = 'check'
+					emitter.emit('progress', state)
+			.tap(win32.prepare)
+			.then (deviceChecksum) ->
+				emitter.emit('done', imageChecksum is deviceChecksum)
+			.asCallback(callback)
 
 	.catch (error) ->
 
@@ -113,94 +153,6 @@ exports.write = (device, stream) ->
 				Please try again, or get in touch with support@resin.io
 			'''
 
-		emitter.emit('error', error)
-
-	return emitter
-
-###*
-# @summary Write a readable stream to a device
-# @function
-# @public
-#
-# @description
-# This function can be used after `write()` to ensure
-# the image was successfully written to the device.
-#
-# This is checked by calculating and comparing checksums
-# of both the original image and the data written to a device.
-#
-# Notice that if you just used `write()`, you usually have
-# to create another readable stream from the image since
-# the one used previously has all its data consumed already,
-# so it will emit no `data` event, leading to false results.
-#
-# The returned EventEmitter instance emits the following events:
-#
-# - `progress`: A progress event that passes a state object of the form:
-#
-# 	{
-# 		percentage: 9.05,
-# 		transferred: 949624,
-# 		length: 10485760,
-# 		remaining: 9536136,
-# 		eta: 10,
-# 		runtime: 0,
-# 		delta: 295396,
-# 		speed: 949624
-# 	}
-#
-# - `error`: An error event.
-# - `done`: An event emitted with a boolean value determining the result of the check.
-#
-# @param {String} device - device
-# @param {ReadStream} stream - image readable stream
-# @returns {EventEmitter} - emitter
-#
-# @example
-# myStream = fs.createReadStream('my/image')
-# myStream.length = fs.statSync('my/image').size
-#
-# checker = imageWrite.check('/dev/disk2', myStream)
-#
-# checker.on 'error', (error) ->
-# 	console.error(error)
-#
-# checker.on 'done', (success) ->
-# 	if success
-# 		console.log('The write was successful')
-###
-exports.check = (device, stream) ->
-	emitter = new EventEmitter()
-
-	Promise.try ->
-		if not stream.length?
-			throw new Error('Stream size missing')
-
-		device = fs.createReadStream(utils.getRawDevice(device))
-
-		# Since both the image and device checksum calculation
-		# rely on the same input stream, we can safely send
-		# both progress states reports to the client at the same.
-		emitProgress = (state) ->
-			emitter.emit('progress', state)
-
-		return Promise.props
-			stream: checksum.calculate stream,
-				bytes: stream.length
-				progress: emitProgress
-
-			# Only calculate the checksum from the bytes that correspond
-			# to the original image size and not the whole drive since
-			# the drive might contain empty space that changes the
-			# resulting checksum.
-			# See https://help.ubuntu.com/community/HowToMD5SUM#Check_the_CD
-			device: checksum.calculate device,
-				bytes: stream.length
-				progress: emitProgress
-
-	.then (checksums) ->
-		emitter.emit('done', checksums.stream is checksums.device)
-	.catch (error) ->
 		emitter.emit('error', error)
 
 	return emitter

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "nock": "^2.6.0",
     "resin-request": "^2.2.5",
     "resin-settings-client": "^3.0.0",
-    "string-to-stream": "^1.0.1",
     "rindle": "^1.3.0",
+    "string-to-stream": "^1.0.1",
     "tmp": "0.0.28",
     "wary": "^1.1.0"
   },
@@ -50,6 +50,7 @@
   "dependencies": {
     "bluebird": "^2.9.30",
     "crc32-stream": "^0.4.0",
+    "denymount": "^2.1.0",
     "lodash": "^3.10.0",
     "progress-stream": "^1.1.1",
     "slice-stream": "^1.0.0",


### PR DESCRIPTION
Currently the `.check()` function failed on OS X and Windows for images
that contain FAT partitions, since these operating systems will
auto-mount the FAT partitions when the drive is complete, and "touch"
some files like `.DS_Store`, causing the checksum to be slightly
different.

This PR also removes `.check()` and instead adds a `check` option to
`.write()`. This is because we need more control on the time slice after
the writing is complete and the check process is started.

OS X
----

For OS X, we use a module called denymount
(https://github.com/resin-io/denymount), which causes the OS to omit
auto-mounting the drives we specify.

Windows
-------

In Windows, we triggered `diskpart rescan` when the writing finished in
order for the OS to catch up with the changes. Turns out we can delay
this until *after* the check, so the new FAT partitions are not
mounted.