### PR TITLE
Upgrade slice-stream to slice-stream2

### DIFF
--- a/build/checksum.js
+++ b/build/checksum.js
@@ -18,7 +18,7 @@ var CRC32Stream, Promise, SliceStream, progressStream, _;
 
 CRC32Stream = require('crc32-stream');
 
-SliceStream = require('slice-stream');
+SliceStream = require('slice-stream2');
 
 Promise = require('bluebird');
 

--- a/lib/checksum.coffee
+++ b/lib/checksum.coffee
@@ -15,7 +15,7 @@ limitations under the License.
 ###
 
 CRC32Stream = require('crc32-stream')
-SliceStream = require('slice-stream')
+SliceStream = require('slice-stream2')
 Promise = require('bluebird')
 progressStream = require('progress-stream')
 _ = require('lodash')

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "denymount": "^2.1.0",
     "lodash": "^3.10.0",
     "progress-stream": "^1.1.1",
-    "slice-stream": "^1.0.0",
+    "slice-stream2": "^1.0.1",
     "stream-chunker": "^1.1.5"
   }
 }


### PR DESCRIPTION
This new version (a fork of the original) contains a fix for the
`stream.push() after EOF` error hit when burning unaligned images.

See https://github.com/jviotti/slice-stream2/pull/1
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>