### PR TITLE
Don't rely on stream.length to determine how many bytes to read back

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "crc32-stream": "^0.4.0",
     "denymount": "^2.1.0",
     "lodash": "^3.10.0",
+    "passthrough-counter": "^1.0.0",
     "progress-stream": "^1.1.1",
     "slice-stream2": "^1.0.1",
     "stream-chunker": "^1.1.5"

--- a/tests/checksum.spec.coffee
+++ b/tests/checksum.spec.coffee
@@ -71,6 +71,14 @@ describe 'Checksum:', ->
 				m.chai.expect(result).to.equal('5f29d461')
 			.nodeify(done)
 
+		it 'should return a checksum for the whole stream if bytes equals Infinity', (done) ->
+			string = 'Lorem ipsum dolor sit amet'
+			checksum.calculate rindle.getStreamFromString(string),
+				bytes: Infinity
+			.then (result) ->
+				m.chai.expect(result).to.equal('5f29d461')
+			.nodeify(done)
+
 		it 'should calculate the checksum from a part of a stream', (done) ->
 			string = 'Lorem ipsum dolor sit amet'
 			checksum.calculate rindle.getStreamFromString(string),


### PR DESCRIPTION
A more accurate approach is to count how many bytes were transferred
during the write, and use that value to determine how many bytes to read
back for validation purposes.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>