### PR TITLE
Align final chunk in unaligned images

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -143,10 +143,11 @@ exports.write = function(device, stream, options) {
             emitter.emit('progress', state);
           })
           .pipe(options.transform || new PassThroughStream())
-          .pipe(streamChunker(CHUNK_SIZE, {
-            flush: true
-          }))
           .pipe(checksumStream)
+          .pipe(streamChunker(CHUNK_SIZE, {
+            flush: true,
+            align: true
+          }))
           .pipe(fs.createWriteStream(device, {
             flags: 'rs+'
           }))

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "lodash": "^3.10.0",
     "progress-stream": "^1.1.1",
     "slice-stream2": "^2.0.0",
-    "stream-chunker": "^1.1.5"
+    "stream-chunker": "^1.2.8"
   }
 }


### PR DESCRIPTION
Prevents `EINVAL` errors.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>