### PR TITLE
Make sure we handle multiple resolves from fs.write correctly

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,8 @@ exports.eraseMBR = function(device) {
   var buffer = new Buffer(bufferSize);
   buffer.fill(0);
   return fs.openAsync(device, 'rs+').then(function(fd) {
-    return fs.writeAsync(fd, buffer, 0, bufferSize, 0).spread(function(bytesWritten) {
+    return fs.writeAsync(fd, buffer, 0, bufferSize, 0).then(function(bytesWritten) {
+      bytesWritten = bytesWritten[0] || bytesWritten;
       if (bytesWritten !== bufferSize) {
         throw new Error('Bytes written: ' + bytesWritten + ', expected ' + bufferSize);
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "diskpart": "^1.0.0"
   },
   "dependencies": {
-    "bluebird": "^2.9.30",
+    "bluebird": "^3.3.5",
     "crc32-stream": "^0.4.0",
     "denymount": "^2.1.0",
     "dev-null-stream": "0.0.1",


### PR DESCRIPTION
In some setups, `.spread()` is needed since `fs.writeAsync` solves an
array, while in others (like Electron), the array is expanded
automatically.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>